### PR TITLE
Implement upload token

### DIFF
--- a/client/conf/conf.go
+++ b/client/conf/conf.go
@@ -13,6 +13,7 @@ import (
 // Configuration is the struct representing a configuration.
 type Configuration struct {
 	Service string `yaml:"service"`
+	Token   string `yaml:"token"`
 }
 
 // C is the exported global configuration variable

--- a/client/main.go
+++ b/client/main.go
@@ -159,6 +159,9 @@ func main() {
 		if once {
 			multipartWriter.WriteField("once", "true")
 		}
+		if conf.C.Token != "" {
+			multipartWriter.WriteField("token", conf.C.Token)
+		}
 		if part, err = multipartWriter.CreateFormFile("file", name); err != nil {
 			log.Fatal(err)
 		}

--- a/server/assets/custom.js
+++ b/server/assets/custom.js
@@ -31,6 +31,8 @@ toastr.options = {
     "hideMethod": "fadeOut"
 };
 
+$('#token').keydown(function (e) { if(e.which == 13) e.preventDefault(); });
+
 var clipboard = new Clipboard('#upload-clipboard');
 clipboard.on('success', function(e) {
     toastr.success('Copied to Clipboard');
@@ -177,6 +179,9 @@ $('#upload-btn').click(function($e) {
     if ($('#one-view').is(":checked")) {
         data.append('once', 'true');
     }
+    if ($('#token').length) {
+        data.append('token', $('#token').val());
+    }
     toastr.success('File transfer in progress');
     form.fadeOut(400, function() {
         loader.fadeIn();
@@ -218,7 +223,7 @@ $('#upload-btn').click(function($e) {
             });
             req.fail(function(jqxhr, statusmsg) {
                 loader.fadeOut(400, function() {
-                    uperror.html("The file is too big or an error occured on the server.").show();
+                    uperror.html("The file is too big, the token is incorrect or an error occured on the server.").show();
                     form.fadeIn(400, function() {
                         $(".progress>div").css("width", "0%");
                     });

--- a/server/conf/conf.go
+++ b/server/conf/conf.go
@@ -18,6 +18,8 @@ type Conf struct {
 	Port       int    `yaml:"port" form:"port"`
 	AppendPort bool   `yaml:"append_port" form:"append_port"`
 
+	Token      string `yaml:"token" form:"token"`
+
 	ServeHTTPS bool   `yaml:"serve_https" form:"serve_https"`
 	SSLCert    string `yaml:"ssl_cert" form:"ssl_cert"`
 	SSLPrivKey string `yaml:"ssl_private_key" form:"ssl_private_key"`
@@ -45,6 +47,8 @@ type UnparsedConf struct {
 	Host       string `yaml:"host" form:"host"`
 	Port       int    `yaml:"port" form:"port"`
 	AppendPort bool   `yaml:"append_port" form:"append_port"`
+
+	Token      string `yaml:"token" form:"token"`
 
 	ServeHTTPS bool   `yaml:"serve_https" form:"serve_https"`
 	SSLCert    string `yaml:"ssl_cert" form:"ssl_cert"`

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -61,8 +61,16 @@
             <h1 class="title">&nbsp;</h1>
             <h2>&nbsp;</h2> 
             {{ end }}
-            <form id="upload-form">
+            <form id="upload-form" method="post">
                 <fieldset class="container">
+                    {{ if .token }}
+                    <div class="row">
+                        <div class="column">
+                            <label for="token">Upload Token</label>
+                            <input id="token" type="password" name="token" placeholder="This site requires a token to upload">
+                        </div>
+                    </div>
+                    {{ end }}
                     <div class="row">
                         <div class="column">
                             <input id="source" type="checkbox" name="source">

--- a/server/views/resources.go
+++ b/server/views/resources.go
@@ -29,6 +29,14 @@ func CreateC(c *gin.Context) {
 
 	once = c.PostForm("once") != ""
 	d := c.DefaultPostForm("duration", "1d")
+	token := c.PostForm("token")
+
+	if conf.C.Token != token {
+			logger.ErrC(c, "server", "Incorrect token")
+			c.String(http.StatusUnauthorized, "Incorrect token\n")
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+	}
 
 	if val, ok := models.DurationMap[d]; ok {
 		duration = val

--- a/server/views/web.go
+++ b/server/views/web.go
@@ -22,6 +22,7 @@ func Index(c *gin.Context) {
 		return
 	}
 	data := gin.H{
+		"token":          conf.C.Token,
 		"fulldoc":        conf.C.FullDoc,
 		"size_limit":     utils.HumanBytes(uint64(conf.C.SizeLimit * utils.MegaByte)),
 		"sensitive_mode": conf.C.SensitiveMode,


### PR DESCRIPTION
This adds an optional token, that must be included in upload requests. Helpful for running (semi-)private installations.

Thanks for a great piece of software!

Fixes #48 