### PR TITLE
Some fixes for forced download

### DIFF
--- a/server/router/router.go
+++ b/server/router/router.go
@@ -33,6 +33,7 @@ func Setup(tbox, abox *rice.Box) (*gin.Engine, error) {
 		r.POST("/", views.Create)
 		r.GET("/v/:uniuri", views.View)
 		r.HEAD("/v/:uniuri", views.Head)
+		r.GET("/v/:uniuri/:lang", views.ViewCode)
 	} else {
 		r.POST("/", views.CreateC)
 		r.GET("/v/:uniuri/:key", views.ViewC)

--- a/server/views/resources.go
+++ b/server/views/resources.go
@@ -163,9 +163,6 @@ func ViewCCode(c *gin.Context) {
 	var iv [aes.BlockSize]byte
 	stream := cipher.NewCFBDecrypter(block, iv[:])
 	reader := &cipher.StreamReader{S: stream, R: f}
-	if conf.C.AlwaysDownload {
-		c.Header("Content-Type", "application/octet-stream")
-	}
 	c.Header("Content-Disposition", "filename=\""+re.Name+"\"")
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(reader)

--- a/server/views/resources.go
+++ b/server/views/resources.go
@@ -121,8 +121,10 @@ func ViewC(c *gin.Context) {
 	reader := &cipher.StreamReader{S: stream, R: f}
 	if conf.C.AlwaysDownload {
 		c.Header("Content-Type", "application/octet-stream")
+		c.Header("Content-Disposition", "attachment; filename=\""+re.Name+"\"")
+	} else {
+		c.Header("Content-Disposition", "filename=\""+re.Name+"\"")
 	}
-	c.Header("Content-Disposition", "filename=\""+re.Name+"\"")
 	io.Copy(c.Writer, reader)
 	if re.Once {
 		re.Delete()
@@ -215,6 +217,11 @@ func HeadC(c *gin.Context) {
 	var iv [aes.BlockSize]byte
 	stream := cipher.NewCFBDecrypter(block, iv[:])
 	reader := &cipher.StreamReader{S: stream, R: f}
-	c.Header("Content-Disposition", "filename=\""+re.Name+"\"")
+	if conf.C.AlwaysDownload {
+		c.Header("Content-Type", "application/octet-stream")
+		c.Header("Content-Disposition", "attachment; filename=\""+re.Name+"\"")
+	} else {
+		c.Header("Content-Disposition", "filename=\""+re.Name+"\"")
+	}
 	io.Copy(c.Writer, reader)
 }

--- a/server/views/unencrypted.go
+++ b/server/views/unencrypted.go
@@ -1,6 +1,7 @@
 package views
 
 import (
+	"bytes"
 	"bufio"
 	"fmt"
 	"io"
@@ -148,4 +149,47 @@ func Head(c *gin.Context) {
 	}
 	c.Header("Content-Disposition", "filename=\""+re.Name+"\"")
 	io.Copy(c.Writer, f)
+}
+
+
+// ViewCode allows to see the file with syntax highliting and extra options
+func ViewCode(c *gin.Context) {
+	var err error
+
+	id := c.Param("uniuri")
+	lang := c.Param("lang")
+	theme := c.DefaultQuery("theme", "dark")
+	lines := c.Query("lines") == "true"
+	re := models.Resource{}
+
+	if err = re.Get(id); err != nil || re.Key == "" {
+		logger.InfoC(c, "server", "Not found", id)
+		c.AbortWithStatus(http.StatusNotFound)
+		return
+	}
+	re.LogFetched(c)
+	f, err := os.Open(path.Join(conf.C.UploadDir, re.Key))
+	if err != nil {
+		logger.ErrC(c, "server", fmt.Sprintf("Couldn't open %s", re.Key), err)
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+	if conf.C.AlwaysDownload {
+		c.Header("Content-Type", "application/octet-stream")
+	}
+	c.Header("Content-Disposition", "filename=\""+re.Name+"\"")
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(f)
+	bb := buf.Bytes()
+	c.HTML(http.StatusOK, "code.tmpl", gin.H{
+		"code":  string(bb),
+		"lang":  lang,
+		"theme": theme,
+		"lines": lines,
+		"name":  re.Name,
+	})
+	if re.Once {
+		re.Delete()
+		re.LogDeleted(c)
+	}
 }

--- a/server/views/unencrypted.go
+++ b/server/views/unencrypted.go
@@ -116,8 +116,10 @@ func View(c *gin.Context) {
 	}
 	if conf.C.AlwaysDownload {
 		c.Header("Content-Type", "application/octet-stream")
+		c.Header("Content-Disposition", "attachment; filename=\""+re.Name+"\"")
+	} else {
+		c.Header("Content-Disposition", "filename=\""+re.Name+"\"")
 	}
-	c.Header("Content-Disposition", "filename=\""+re.Name+"\"")
 	io.Copy(c.Writer, f)
 	if re.Once {
 		re.Delete()
@@ -146,8 +148,10 @@ func Head(c *gin.Context) {
 	}
 	if conf.C.AlwaysDownload {
 		c.Header("Content-Type", "application/octet-stream")
+		c.Header("Content-Disposition", "attachment; filename=\""+re.Name+"\"")
+	} else {
+		c.Header("Content-Disposition", "filename=\""+re.Name+"\"")
 	}
-	c.Header("Content-Disposition", "filename=\""+re.Name+"\"")
 	io.Copy(c.Writer, f)
 }
 

--- a/server/views/unencrypted.go
+++ b/server/views/unencrypted.go
@@ -174,9 +174,6 @@ func ViewCode(c *gin.Context) {
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return
 	}
-	if conf.C.AlwaysDownload {
-		c.Header("Content-Type", "application/octet-stream")
-	}
 	c.Header("Content-Disposition", "filename=\""+re.Name+"\"")
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(f)


### PR DESCRIPTION
This disables the "force download" mode when "view code" is requested (does not make much sense, I would say).

It also adds the "attachment" keyword in the "Content-Disposition" header. This is the correct way to ask the browser to show the "Save as" dialog and without it at least Firefox will not download the file but still show it inline.

Depends on #59.