### PR TITLE
Add UnixDeleteAt for unencrypted uploads

### DIFF
--- a/server/views/unencrypted.go
+++ b/server/views/unencrypted.go
@@ -74,11 +74,13 @@ func Create(c *gin.Context) {
 			return
 		}
 	}
+	del := time.Now().Add(duration)
 	newres := &models.Resource{
 		Key:      u,
 		Name:     h.Filename,
 		Once:     once,
-		DeleteAt: time.Now().Add(duration),
+		DeleteAt: del,
+		UnixDeleteAt: del.Unix(),
 		Size:     wr,
 	}
 	if err = newres.Save(); err != nil {


### PR DESCRIPTION
This fixes a bug introduced in a3fbf077 where `UnixDeleteAt` was introduced from encrypted, but not for unencrypted files.