### PR TITLE
fix: the application stores the original filename fr... in resources.go

### DIFF
--- a/server/views/resources.go
+++ b/server/views/resources.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -115,11 +116,12 @@ func ViewC(c *gin.Context) {
 	var iv [aes.BlockSize]byte
 	stream := cipher.NewCTR(block, iv[:])
 	reader := &cipher.StreamReader{S: stream, R: f}
+	safeName := strings.NewReplacer("\r", "", "\n", "").Replace(re.Name)
 	if conf.C.AlwaysDownload {
 		c.Header("Content-Type", "application/octet-stream")
-		c.Header("Content-Disposition", "attachment; filename=\""+re.Name+"\"")
+		c.Header("Content-Disposition", "attachment; filename=\""+safeName+"\"")
 	} else {
-		c.Header("Content-Disposition", "filename=\""+re.Name+"\"")
+		c.Header("Content-Disposition", "filename=\""+safeName+"\"")
 	}
 
 	if _, err := io.Copy(c.Writer, reader); err != nil {
@@ -176,7 +178,8 @@ func ViewCCode(c *gin.Context) {
 	var iv [aes.BlockSize]byte
 	stream := cipher.NewCTR(block, iv[:])
 	reader := &cipher.StreamReader{S: stream, R: f}
-	c.Header("Content-Disposition", "filename=\""+re.Name+"\"")
+	safeName := strings.NewReplacer("\r", "", "\n", "").Replace(re.Name)
+	c.Header("Content-Disposition", "filename=\""+safeName+"\"")
 	buf := new(bytes.Buffer)
 	if _, err := buf.ReadFrom(reader); err != nil {
 		logger.ErrC(c, "server", "Couldn't read from file", err)
@@ -239,11 +242,12 @@ func HeadC(c *gin.Context) {
 	var iv [aes.BlockSize]byte
 	stream := cipher.NewCTR(block, iv[:])
 	reader := &cipher.StreamReader{S: stream, R: f}
+	safeName := strings.NewReplacer("\r", "", "\n", "").Replace(re.Name)
 	if conf.C.AlwaysDownload {
 		c.Header("Content-Type", "application/octet-stream")
-		c.Header("Content-Disposition", "attachment; filename=\""+re.Name+"\"")
+		c.Header("Content-Disposition", "attachment; filename=\""+safeName+"\"")
 	} else {
-		c.Header("Content-Disposition", "filename=\""+re.Name+"\"")
+		c.Header("Content-Disposition", "filename=\""+safeName+"\"")
 	}
 	if _, err := io.Copy(c.Writer, reader); err != nil {
 		logger.ErrC(c, "server", fmt.Sprintf("Couldn't copy %s", re.Key), err)


### PR DESCRIPTION
## Summary
Fix high severity security issue in `server/views/resources.go`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `server/views/resources.go:97` |
| **Assessment** | Likely exploitable |

**Description**: The application stores the original filename from user uploads and uses it directly in Content-Disposition headers without sanitization. While file storage uses a generated unique key, the original filename is preserved and reflected back to users in HTTP headers, allowing injection of special characters or CRLF sequences.

## Evidence

**Exploitation scenario**: Attacker uploads a file with a crafted filename containing CRLF sequences (e.g., 'malicious.txt\r\nX-Injected-Header: value').

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This view handler appears to be publicly accessible. This is a Go service - vulnerabilities in HTTP handlers are remotely exploitable.

## Changes
- `server/views/resources.go`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
